### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Continuous Integration
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Oussemasahbeni/konnect-spring-boot-starter/security/code-scanning/1](https://github.com/Oussemasahbeni/konnect-spring-boot-starter/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow or the specific job to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the job only checks out code and runs tests, it only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the top level of the workflow (just after the `name:` and before `on:`), so it applies to all jobs unless overridden. No other changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
